### PR TITLE
feat(list-secrets): attach to process env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/credential-providers": "^3.758.0",
         "@aws-sdk/protocol-http": "^3.370.0",
         "@aws-sdk/signature-v4": "^3.370.0",
-        "axios": "^1.7.5",
+        "axios": "^1.11.0",
         "typescript": "^5.5.4",
         "zod": "^3.23.8"
       },
@@ -2497,13 +2497,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2851,14 +2851,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@aws-sdk/credential-providers": "^3.758.0",
     "@aws-sdk/protocol-http": "^3.370.0",
     "@aws-sdk/signature-v4": "^3.370.0",
-    "axios": "^1.7.5",
+    "axios": "^1.11.0",
     "typescript": "^5.5.4",
     "zod": "^3.23.8"
   },

--- a/src/api/types/secrets.ts
+++ b/src/api/types/secrets.ts
@@ -108,6 +108,7 @@ export type ListSecretsOptions = {
   environment: string;
   projectId: string;
   expandSecretReferences?: boolean;
+  attachToProcessEnv?: boolean;
   includeImports?: boolean;
   recursive?: boolean;
   secretPath?: string;

--- a/src/custom/secrets.ts
+++ b/src/custom/secrets.ts
@@ -16,7 +16,7 @@ export default class SecretsClient {
 
   listSecrets = async (options: ListSecretsOptions) => {
     try {
-      return await this.apiClient.listSecrets({
+      const res = await this.apiClient.listSecrets({
         workspaceId: options.projectId,
         environment: options.environment,
         expandSecretReferences: convertBool(
@@ -28,6 +28,15 @@ export default class SecretsClient {
         tagSlugs: options.tagSlugs ? options.tagSlugs.join(",") : undefined,
         viewSecretValue: convertBool(options.viewSecretValue ?? true),
       });
+
+      if (options.attachToProcessEnv) {
+				for (const secret of res.secrets) {
+					process.env[secret.secretKey] = secret.secretValue;
+				}
+			}
+
+      return res;
+
     } catch (err) {
       throw newInfisicalError(err);
     }


### PR DESCRIPTION
This PR adds support for attaching secrets to the process env. This is something we supported in our <3.0.0 SDK, but it was never ported over to 3.0.0.