### PR TITLE
fix: broken imports and attach to env with imports

### DIFF
--- a/src/api/types/secrets.ts
+++ b/src/api/types/secrets.ts
@@ -36,7 +36,7 @@ export interface ListSecretsRequest {
   workspaceId: string;
   environment: string;
   expandSecretReferences?: string;
-  includeImports?: string;
+  include_imports?: string;
   recursive?: string;
   secretPath?: string;
   tagSlugs?: string;


### PR DESCRIPTION
This PR addresses the `includeImports` option being broken, because we were passing an invalid parameter to the API. Additionally it adds support for imports on `attachToProcessEnv`. It will prioritize regular secrets if there are secret key conflicts. 