### PR TITLE
feat!: migrate to ky for broader runtime support

### DIFF
--- a/.cursor/agents/staff-node-typescript.md
+++ b/.cursor/agents/staff-node-typescript.md
@@ -1,0 +1,27 @@
+---
+name: staff-node-typescript
+description: Staff-level Node.js, Bun, Deno, and TypeScript engineer. Use proactively for API design, runtime differences, module systems, performance, testing strategy, typing, and shipping maintainable libraries or services. Delegate for architecture decisions, refactors, reviews, and hard technical tradeoffs in JS/TS ecosystems.
+---
+
+You are a staff software engineer with deep expertise in Node.js, Bun, Deno, and TypeScript. You have a consistent track record of delivering high-quality, scalable, testable, and clean code in production systems and open-source libraries.
+
+## Principles
+
+- **Correctness first**: Prefer explicit types, narrow APIs, and predictable behavior over clever shortcuts.
+- **Minimal surface area**: Solve the problem with the smallest coherent change; avoid drive-by refactors unless asked.
+- **Runtime awareness**: When behavior differs across Node, Bun, or Deno (globals, module resolution, timers, streams, crypto, fetch, workers), call it out and choose portable patterns or document constraints.
+- **Testability**: Design seams (dependency injection, pure functions, small modules) so behavior can be verified with unit and integration tests; suggest tests when they close a real gap.
+- **Observability & ops**: Consider logging, metrics, and failure modes for services; for libraries, consider debuggability and error messages consumers will see.
+
+## When invoked
+
+1. Clarify constraints (target runtimes, Node version, package manager, test runner, bundler if relevant).
+2. Read existing code and match local conventions (naming, structure, error style, exports).
+3. Propose or implement changes that fit the codebase; explain non-obvious tradeoffs briefly.
+4. For public APIs or shared types, prioritize backward compatibility and clear documentation in code where the project already documents.
+
+## Output
+
+- Prefer concrete recommendations and, when implementing, code that matches the repository’s style.
+- For reviews: organize feedback by severity (must fix / should fix / consider), with specific suggestions.
+- Avoid filler; be direct. Do not claim to have run commands or tests unless you actually did in that session.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,20 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/credential-providers": "3.993.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "axios": "^1.11.0",
-        "typescript": "^5.5.4",
+        "@smithy/protocol-http": "5.3.13",
+        "@smithy/signature-v4": "5.3.13",
+        "ky": "2.0.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@types/node": "^22.5.1",
-        "tsc": "^2.0.4",
-        "tsup": "^8.2.4"
+        "@types/node": "^24.0.0",
+        "tsup": "^8.5.1",
+        "typescript": "^5.5.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -1098,13 +1100,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
-      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "fast-xml-parser": "5.4.1",
+        "@smithy/types": "^4.14.0",
+        "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2225,12 +2227,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
-      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
+      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2290,16 +2292,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
-      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
+      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.13",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -2340,9 +2342,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
-      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2501,12 +2503,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
-      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
+      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2629,13 +2631,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/acorn": {
@@ -2657,23 +2659,6 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "node_modules/bowser": {
       "version": "2.14.1",
@@ -2707,19 +2692,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -2734,18 +2706,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -2793,74 +2753,6 @@
         }
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -2868,6 +2760,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2904,21 +2797,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -2927,8 +2808,24 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2964,42 +2861,6 @@
         "rollup": "^4.34.8"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3015,103 +2876,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -3120,6 +2884,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ky": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-2.0.0.tgz",
+      "integrity": "sha512-KzI4Vz5AbZFAUFYGx28PCSfFWUo6/qj9Br/P6KRwDieE1xfdz0tIONepJcLw/1xLocN13GgvfJGasa+pfSkbHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
     "node_modules/lilconfig": {
@@ -3160,36 +2936,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mlly": {
@@ -3234,6 +2980,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3249,11 +3010,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3325,12 +3087,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -3412,9 +3168,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -3510,16 +3266,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/tsc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.4.tgz",
-      "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsc": "bin/tsc"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3583,7 +3329,9 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3600,9 +3348,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,51 +1,59 @@
 {
   "name": "@infisical/sdk",
   "version": "0.0.0",
-  "main": "./lib/index.js",
   "private": false,
-  "files": [
-    "lib"
-  ],
-  "scripts": {
-    "build": "tsup src/index.ts --out-dir lib --dts --format cjs,esm --tsconfig tsconfig.json --no-splitting"
-  },
+  "description": "The Infisical SDK provides a convenient way to programmatically interact with the Infisical API.",
   "keywords": [
     "infisical",
     "open-source",
     "sdk",
     "typescript"
   ],
+  "homepage": "https://github.com/infisical/infisical-node-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/infisical/infisical-node-sdk/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/infisical/infisical-node-sdk.git"
   },
-  "author": "Infisical Inc, <daniel@infisical.com>",
   "license": "ISC",
-  "description": "The Infisical SDK provides a convenient way to programmatically interact with the Infisical API.",
-  "devDependencies": {
-    "@types/node": "^22.5.1",
-    "tsc": "^2.0.4",
-    "tsup": "^8.2.4"
+  "author": "Infisical Inc, <daniel@infisical.com>",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.mjs",
+  "types": "./lib/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./lib/cjs/index.d.ts",
+        "import": "./lib/cjs/index.js"
+      },
+      "import": {
+        "types": "./lib/esm/index.d.mts",
+        "import": "./lib/esm/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "rm -rf lib && tsup"
   },
   "dependencies": {
-    "@aws-crypto/sha256-js": "^5.2.0",
+    "@aws-crypto/sha256-js": "5.2.0",
     "@aws-sdk/credential-providers": "3.993.0",
-    "@smithy/protocol-http": "^5.3.8",
-    "@smithy/signature-v4": "^5.3.8",
-    "axios": "^1.11.0",
-    "typescript": "^5.5.4",
+    "@smithy/protocol-http": "5.3.13",
+    "@smithy/signature-v4": "5.3.13",
+    "ky": "2.0.0",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.5.4"
   },
   "engines": {
     "node": ">=20"
-  },
-  "directories": {
-    "lib": "lib",
-    "test": "test"
-  },
-  "types": "./lib/index.d.ts",
-  "bugs": {
-    "url": "https://github.com/infisical/infisical-node-sdk/issues"
-  },
-  "homepage": "https://github.com/infisical/infisical-node-sdk#readme"
+  }
 }

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -6,6 +6,9 @@ export interface ApiClientConfig {
   timeout?: number;
 }
 
+const isJsonContentType = (contentType: string): boolean =>
+  contentType.split(";")[0]?.trim().toLowerCase() === "application/json";
+
 export class ApiClient {
   private client: KyInstance;
 
@@ -14,6 +17,8 @@ export class ApiClient {
     const initialRetryDelay = 1000;
     const backoffFactor = 2;
 
+    // Ky reads error response bodies before retrying HTTP errors (including 429), so the
+    // underlying connection is not left with an unconsumed body during backoff (unlike ad-hoc fetch retries).
     this.client = ky.create({
       baseUrl: config.baseURL,
       headers: config.headers || {},
@@ -22,10 +27,39 @@ export class ApiClient {
         limit: maxRetries,
         methods: ['get', 'post', 'put', 'patch', 'head', 'delete', 'options', 'trace'],
         statusCodes: [429],
-        delay: (attemptCount) => initialRetryDelay * Math.pow(backoffFactor, attemptCount - 1),
-        jitter: (delay) => delay * (0.8 + Math.random() * 0.4),
+        delay: (attemptCount: number) =>
+          initialRetryDelay * Math.pow(backoffFactor, attemptCount - 1),
+        jitter: (delay: number) => delay * (0.8 + Math.random() * 0.4),
       }
     });
+  }
+
+  /** Maps JSON vs raw body for ky: non-JSON Content-Type must use a string or URLSearchParams, not a plain object. */
+  private optionsWithBody(data: unknown, config?: KyOptions): KyOptions {
+    if (data === undefined) {
+      return { ...config };
+    }
+
+    const headers = config?.headers as Record<string, string | undefined> | undefined;
+
+    const explicitCt =
+      headers?.["Content-Type"] ?? headers?.["content-type"];
+
+    if (explicitCt === undefined || isJsonContentType(explicitCt)) {
+      return { ...config, json: data };
+    }
+
+    if (typeof data === "string") {
+      return { ...config, body: data };
+    }
+
+    if (data instanceof URLSearchParams) {
+      return { ...config, body: data.toString() };
+    }
+
+    throw new TypeError(
+      `Request body for Content-Type "${explicitCt}" must be a string or URLSearchParams; received ${Object.prototype.toString.call(data)}`
+    );
   }
 
   public setAccessToken(token: string) {
@@ -42,34 +76,25 @@ export class ApiClient {
 
   public async post<T>(
     url: string,
-    data?: Record<string, any>,
+    data?: unknown,
     config?: KyOptions
   ): Promise<T> {
-    return await this.client.post<T>(url, {
-      ...config,
-      json: data,
-    }).json();
+    return await this.client.post<T>(url, this.optionsWithBody(data, config)).json();
   }
 
   public async patch<T>(
     url: string,
-    data?: Record<string, any>,
+    data?: unknown,
     config?: KyOptions
   ): Promise<T> {
-    return await this.client.patch<T>(url, {
-      ...config,
-      json: data,
-    }).json();
+    return await this.client.patch<T>(url, this.optionsWithBody(data, config)).json();
   }
 
   public async delete<T>(
     url: string,
-    data?: Record<string, any>,
+    data?: unknown,
     config?: KyOptions
   ): Promise<T> {
-    return await this.client.delete<T>(url, {
-      ...config,
-      json: data,
-    }).json();
+    return await this.client.delete<T>(url, this.optionsWithBody(data, config)).json();
   }
 }

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
+import ky, { KyInstance, Options as KyOptions } from "ky";
 
 export interface ApiClientConfig {
   baseURL: string;
@@ -7,87 +7,69 @@ export interface ApiClientConfig {
 }
 
 export class ApiClient {
-  private client: AxiosInstance;
+  private client: KyInstance;
 
   constructor(config: ApiClientConfig) {
-    this.client = axios.create({
-      baseURL: config.baseURL,
-      headers: config.headers || {},
-      timeout: config.timeout || 10000,
-    });
-
-    this.setupRetryInterceptor();
-  }
-
-  private setupRetryInterceptor() {
     const maxRetries = 4;
     const initialRetryDelay = 1000;
     const backoffFactor = 2;
 
-    this.client.interceptors.response.use(null, (error) => {
-      const config = error?.config;
-      if (!config) return Promise.reject(error);
-
-      if (!config._retryCount) config._retryCount = 0;
-
-      // handle rate limits and network errors
-      if (
-        (error.response?.status === 429 ||
-          error.response?.status === undefined) &&
-        config._retryCount < maxRetries
-      ) {
-        config._retryCount++;
-        const baseDelay =
-          initialRetryDelay * Math.pow(backoffFactor, config._retryCount - 1);
-        const jitter = baseDelay * 0.2;
-        const exponentialDelay = baseDelay + (Math.random() * 2 - 1) * jitter;
-
-        return new Promise((resolve) => {
-          setTimeout(() => resolve(this.client(config)), exponentialDelay);
-        });
+    this.client = ky.create({
+      baseUrl: config.baseURL,
+      headers: config.headers || {},
+      timeout: config.timeout || 10000,
+      retry: {
+        limit: maxRetries,
+        methods: ['get', 'post', 'put', 'patch', 'head', 'delete', 'options', 'trace'],
+        statusCodes: [429],
+        delay: (attemptCount) => initialRetryDelay * Math.pow(backoffFactor, attemptCount - 1),
+        jitter: (delay) => delay * (0.8 + Math.random() * 0.4),
       }
-
-      return Promise.reject(error);
     });
   }
 
   public setAccessToken(token: string) {
-    this.client.defaults.headers.common["Authorization"] = `Bearer ${token}`;
+    this.client = this.client.extend({
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
   }
 
-  public async get<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    const response: AxiosResponse<T> = await this.client.get(url, config);
-    return response.data;
+  public async get<T>(url: string, config?: KyOptions): Promise<T> {
+    return await this.client.get<T>(url, config).json();
   }
 
   public async post<T>(
     url: string,
-    data?: any,
-    config?: AxiosRequestConfig
+    data?: Record<string, any>,
+    config?: KyOptions
   ): Promise<T> {
-    const response: AxiosResponse<T> = await this.client.post(
-      url,
-      data,
-      config
-    );
-    return response.data;
+    return await this.client.post<T>(url, {
+      ...config,
+      json: data,
+    }).json();
   }
 
   public async patch<T>(
     url: string,
-    data?: any,
-    config?: AxiosRequestConfig
+    data?: Record<string, any>,
+    config?: KyOptions
   ): Promise<T> {
-    const response: AxiosResponse<T> = await this.client.patch(
-      url,
-      data,
-      config
-    );
-    return response.data;
+    return await this.client.patch<T>(url, {
+      ...config,
+      json: data,
+    }).json();
   }
 
-  public async delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    const response: AxiosResponse<T> = await this.client.delete(url, config);
-    return response.data;
+  public async delete<T>(
+    url: string,
+    data?: Record<string, any>,
+    config?: KyOptions
+  ): Promise<T> {
+    return await this.client.delete<T>(url, {
+      ...config,
+      json: data,
+    }).json();
   }
 }

--- a/src/api/endpoints/dynamic-secrets.ts
+++ b/src/api/endpoints/dynamic-secrets.ts
@@ -30,7 +30,7 @@ export class DynamicSecretsApi {
   ): Promise<DeleteDynamicSecretResponse> {
     return this.apiClient.delete<DeleteDynamicSecretResponse>(
       `/api/v1/dynamic-secrets/${encodeURIComponent(secretName)}`,
-      { data }
+      data
     );
   }
 
@@ -48,7 +48,7 @@ export class DynamicSecretsApi {
     ): Promise<DeleteLeaseResponse> => {
       return this.apiClient.delete<DeleteLeaseResponse>(
         `/api/v1/dynamic-secrets/leases/${leaseId}`,
-        { data }
+        data
       );
     },
 

--- a/src/api/endpoints/folders.ts
+++ b/src/api/endpoints/folders.ts
@@ -10,7 +10,7 @@ export class FoldersApi {
 
   async listFolders(queryParams: ListFoldersRequest): Promise<ListFoldersResponse> {
     return this.apiClient.get<ListFoldersResponse>("/api/v1/folders", {
-      params: queryParams
+      searchParams: { ...queryParams }
     });
   }
 }

--- a/src/api/endpoints/secrets.ts
+++ b/src/api/endpoints/secrets.ts
@@ -17,7 +17,7 @@ export class SecretsApi {
 
   async listSecrets(params: ListSecretsRequest): Promise<ListSecretsResponse> {
     return this.apiClient.get<ListSecretsResponse>("/api/v3/secrets/raw", {
-      params,
+      searchParams: { ...params },
     });
   }
 
@@ -25,7 +25,7 @@ export class SecretsApi {
     const { secretName, ...queryParams } = params;
     return this.apiClient.get<GetSecretResponse>(
       `/api/v3/secrets/raw/${encodeURIComponent(secretName)}`,
-      { params }
+      { searchParams: queryParams }
     );
   }
 
@@ -55,7 +55,7 @@ export class SecretsApi {
   ): Promise<DeleteSecretResponse> {
     return this.apiClient.delete<DeleteSecretResponse>(
       `/api/v3/secrets/raw/${encodeURIComponent(secretName)}`,
-      { data }
+      data
     );
   }
 }

--- a/src/custom/dynamic-secrets.ts
+++ b/src/custom/dynamic-secrets.ts
@@ -1,5 +1,4 @@
 import { DynamicSecretsApi } from "../api/endpoints/dynamic-secrets";
-import { TDynamicSecretProvider } from "./schemas/dynamic-secrets";
 import { newInfisicalError } from "./errors";
 import {
   CreateDynamicSecretOptions,

--- a/src/custom/errors.ts
+++ b/src/custom/errors.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { isHTTPError } from "ky";
 
 export class InfisicalSDKError extends Error {
   constructor(message: string) {
@@ -24,25 +24,24 @@ export class InfisicalSDKRequestError extends Error {
 }
 
 export const newInfisicalError = (error: any) => {
-  if (axios.isAxiosError(error)) {
-    const data = error?.response?.data;
+  if (isHTTPError(error)) {
+    const data = error.data as { message?: string } | undefined;
 
     if (data?.message) {
       let message = data.message;
-      if (error.response?.status === 422) {
+      if (error.response.status === 422) {
         message = JSON.stringify(data);
       }
 
       return new InfisicalSDKRequestError(message, {
-        url: error.response?.config.url || "",
-        method: error.response?.config.method || "",
-        statusCode: error.response?.status || 0,
+        url: error.request.url,
+        method: error.request.method,
+        statusCode: error.response.status,
       });
     } else if (error.message) {
       return new InfisicalSDKError(error.message);
-    } else if (error.code) {
-      // If theres no message but a code is present, it's likely to be an aggregation error. This is not specific to Axios, but it falls under the AxiosError type
-      return new InfisicalSDKError(error.code);
+    } else if (error.response.status) {
+      return new InfisicalSDKError(error.response.status.toString());
     } else {
       return new InfisicalSDKError("Request failed with unknown error");
     }

--- a/src/custom/errors.ts
+++ b/src/custom/errors.ts
@@ -38,13 +38,17 @@ export const newInfisicalError = (error: any) => {
         method: error.request.method,
         statusCode: error.response.status,
       });
-    } else if (error.message) {
-      return new InfisicalSDKError(error.message);
-    } else if (error.response.status) {
-      return new InfisicalSDKError(error.response.status.toString());
-    } else {
-      return new InfisicalSDKError("Request failed with unknown error");
     }
+
+    if (error.message) {
+      return new InfisicalSDKError(error.message);
+    }
+
+    return new InfisicalSDKError(
+      error.response.status != null
+        ? `Request failed with status ${error.response.status}`
+        : "Request failed with unknown error"
+    );
   }
 
   return new InfisicalSDKError(error?.message || "An error occurred");

--- a/src/custom/util.ts
+++ b/src/custom/util.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { AWS_IDENTITY_DOCUMENT_URI, AWS_TOKEN_METADATA_URI } from "./constants";
 
 import { Sha256 } from "@aws-crypto/sha256-js";
@@ -8,6 +7,7 @@ import { SignatureV4 } from "@smithy/signature-v4";
 
 import { InfisicalSDKError } from "./errors";
 import { Secret } from "../api/types";
+import ky from "ky";
 
 export const getUniqueSecretsByKey = (secrets: Secret[]) => {
 	const secretMap = new Map<string, Secret>();
@@ -25,26 +25,22 @@ export const getAwsRegion = async () => {
 		return region;
 	}
 
-	try {
-		const tokenRes = await axios.put(AWS_TOKEN_METADATA_URI, undefined, {
-			headers: {
-				"X-aws-ec2-metadata-token-ttl-seconds": "21600"
-			},
-			timeout: 5_000 // 5 seconds
-		});
+	const tokenRes = await ky.put(AWS_TOKEN_METADATA_URI, {
+		headers: {
+			"X-aws-ec2-metadata-token-ttl-seconds": "21600"
+		},
+		timeout: 5_000
+	});
 
-		const identityResponse = await axios.get<{ region: string }>(AWS_IDENTITY_DOCUMENT_URI, {
-			headers: {
-				"X-aws-ec2-metadata-token": tokenRes.data,
-				Accept: "application/json"
-			},
-			timeout: 5_000
-		});
+	const identityResponse = await ky.get<{ region: string }>(AWS_IDENTITY_DOCUMENT_URI, {
+		headers: {
+			"X-aws-ec2-metadata-token": await tokenRes.text(),
+			Accept: "application/json"
+		},
+		timeout: 5_000
+	});
 
-		return identityResponse.data.region;
-	} catch (e) {
-		throw e;
-	}
+	return (await identityResponse.json<{ region: string }>()).region;
 };
 
 export const performAwsIamLogin = async (region: string) => {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -9,12 +9,454 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "fs": "^0.0.1-security",
         "https": "^1.0.0",
         "typescript": "^5.5.4"
       },
       "devDependencies": {
-        "@types/node": "^22.5.1"
+        "@types/node": "^22.5.1",
+        "tsx": "^4.21.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/node": {
@@ -27,17 +469,111 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
-      "license": "ISC"
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
     },
     "node_modules/https": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
       "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
       "license": "ISC"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.5.4",

--- a/test/package.json
+++ b/test/package.json
@@ -10,11 +10,11 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "fs": "^0.0.1-security",
     "https": "^1.0.0",
     "typescript": "^5.5.4"
   },
   "devDependencies": {
-    "@types/node": "^22.5.1"
+    "@types/node": "^22.5.1",
+    "tsx": "^4.21.0"
   }
 }

--- a/test/read-only.ts
+++ b/test/read-only.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { InfisicalSDK } from "../src";
+
+const SITE_URL = process.env.SITE_URL || "https://app.infisical.com";
+
+function requireEnv(name: string): string {
+	const value = process.env[name];
+	if (!value) {
+		console.error(`Missing required environment variable: ${name}`);
+		process.exit(1);
+	}
+	return value;
+}
+
+async function run(tests: Array<{ name: string; fn: () => Promise<void> }>) {
+	let passed = 0;
+	let failed = 0;
+
+	for (const test of tests) {
+		try {
+			await test.fn();
+			console.log(`  PASS  ${test.name}`);
+			passed++;
+		} catch (err: any) {
+			console.error(`  FAIL  ${test.name}`);
+			console.error(`        ${err.message}`);
+			failed++;
+		}
+	}
+
+	console.log(`\n${passed} passed, ${failed} failed, ${tests.length} total`);
+
+	if (failed > 0) {
+		process.exit(1);
+	}
+}
+
+(async () => {
+	const clientId = requireEnv("UNIVERSAL_AUTH_CLIENT_ID");
+	const clientSecret = requireEnv("UNIVERSAL_AUTH_CLIENT_SECRET");
+	const projectId = requireEnv("PROJECT_ID");
+	const environmentSlug = requireEnv("ENVIRONMENT_SLUG");
+
+	const client = new InfisicalSDK({ siteUrl: SITE_URL });
+
+	await client.auth().universalAuth.login({
+		clientId,
+		clientSecret,
+	});
+
+	console.log(`\nRunning read-only tests against ${SITE_URL}\n`);
+
+	let firstSecretKey: string | undefined;
+
+	await run([
+		{
+			name: "auth: getAccessToken returns a non-empty string",
+			fn: async () => {
+				const token = client.auth().getAccessToken();
+				assert.ok(token, "access token should be truthy");
+				assert.equal(typeof token, "string");
+				assert.ok(token.length > 0, "access token should not be empty");
+			},
+		},
+		{
+			name: "secrets: listSecrets returns secrets array",
+			fn: async () => {
+				const res = await client.secrets().listSecrets({
+					projectId,
+					environment: environmentSlug,
+				});
+
+				assert.ok(res, "response should be defined");
+				assert.ok(Array.isArray(res.secrets), "secrets should be an array");
+
+				for (const secret of res.secrets) {
+					assert.equal(typeof secret.id, "string", "secret.id should be a string");
+					assert.equal(typeof secret.secretKey, "string", "secret.secretKey should be a string");
+					assert.equal(typeof secret.secretValue, "string", "secret.secretValue should be a string");
+				}
+
+				if (res.secrets.length > 0) {
+					firstSecretKey = res.secrets[0].secretKey;
+				}
+			},
+		},
+		{
+			name: "secrets: listSecretsWithImports returns an array",
+			fn: async () => {
+				const secrets = await client.secrets().listSecretsWithImports({
+					projectId,
+					environment: environmentSlug,
+				});
+
+				assert.ok(Array.isArray(secrets), "result should be an array");
+
+				for (const secret of secrets) {
+					assert.equal(typeof secret.secretKey, "string", "secretKey should be a string");
+				}
+			},
+		},
+		{
+			name: "secrets: getSecret retrieves a specific secret by name",
+			fn: async () => {
+				if (!firstSecretKey) {
+					console.log("        (skipped — no secrets in project)");
+					return;
+				}
+
+				const secret = await client.secrets().getSecret({
+					secretName: firstSecretKey,
+					projectId,
+					environment: environmentSlug,
+				});
+
+				assert.ok(secret, "secret should be defined");
+				assert.equal(secret.secretKey, firstSecretKey, "secretKey should match the requested name");
+				assert.equal(typeof secret.id, "string", "secret.id should be a string");
+				assert.equal(typeof secret.secretValue, "string", "secret.secretValue should be a string");
+			},
+		},
+		{
+			name: "folders: listFolders returns an array",
+			fn: async () => {
+				const folders = await client.folders().listFolders({
+					projectId,
+					environment: environmentSlug,
+					path: "/",
+				});
+
+				assert.ok(Array.isArray(folders), "folders should be an array");
+
+				for (const folder of folders) {
+					assert.equal(typeof folder.id, "string", "folder.id should be a string");
+					assert.equal(typeof folder.name, "string", "folder.name should be a string");
+				}
+			},
+		},
+	]);
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "es6",
+		"target": "es2022",
 		"module": "commonjs",
 		"declaration": true,
 		"rootDir": "./src",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    sourcemap: true,
+    format: 'cjs',
+    dts: true,
+    treeshake: true,
+    cjsInterop: true,
+    outDir: 'lib/cjs',
+    target: 'es2017'
+  },
+  {
+    entry: ['src/index.ts'],
+    sourcemap: true,
+    external: ['ky'],
+    format: 'esm',
+    dts: true,
+    treeshake: true,
+    outDir: 'lib/esm',
+    target: 'es2022'
+  },
+])


### PR DESCRIPTION
## Summary

- Replace `axios` with [`ky`](https://github.com/sindresorhus/ky) v2 as the HTTP client, removing the Node.js-only dependency in favor of a lightweight, Fetch-based alternative with broader runtime support
- Migrate from deprecated `@aws-sdk/protocol-http` and `@aws-sdk/signature-v4` to their `@smithy/*` replacements, and bump `@aws-sdk/credential-providers` from 3.600 to 3.993
- Fixed dual CJS/ESM package exports via `tsup` and conditional `exports` field
- Add read-only integration test suite using `node:assert`

## Breaking Changes

- Minimum Node.js version raised from 14 to **20** (required by AWS SDK v3.993+ and ky v2)
- `axios` removed entirely — error objects thrown by the SDK now originate from ky (`HTTPError`) rather than `AxiosError`

## Details

**HTTP client (`src/api/base.ts`):**
- Replaced axios instance + custom retry interceptor with `ky.create()` using ky's built-in `retry` options
- Retry behavior preserved: 4 retries, exponential backoff (1s × 2^(n-1)), ±20% jitter, 429-only, all HTTP methods

**Request option fixes (`src/api/endpoints/`):**
- `params` (axios) → `searchParams` (ky) in `folders.ts` and `secrets.ts` — without this, query parameters were silently dropped
- `{ data }` wrapper on DELETE (axios) → positional `data` arg mapped to `json` in `secrets.ts` and `dynamic-secrets.ts` — without this, DELETE bodies were silently dropped

**Error handling (`src/custom/errors.ts`):**
- `axios.isAxiosError()` → `isHTTPError()` from ky
- `error.response.data` → `error.data` (ky pre-parses the body; calling `.json()` again would throw "body already read")
- Removed `async` from `newInfisicalError` — the function was called without `await` at all 31 call sites, so `throw newInfisicalError(err)` was throwing a `Promise` instead of an `Error`

**AWS utilities (`src/custom/util.ts`):**
- `axios.put`/`axios.get` for EC2 metadata → `ky.put`/`ky.get` with Fetch-style `.text()` and `.json()` response handling

**Build & packaging:**
- Added `tsup.config.ts` for dual CJS/ESM output
- Added conditional `exports` map in `package.json`
- Moved `typescript` from `dependencies` to `devDependencies`
- Removed `node-fetch`, `@types/node-fetch`, and `tsc` dependencies

## Test Plan

- [x] `npm run build` produces dual CJS/ESM output in `lib/`
- [x] Read-only integration tests pass: `npx tsx test/read-only.ts`
- [x] `listSecrets`, `getSecret`, `listFolders` return correct data (previously broken by `params` → `searchParams` gap)
- [x] `deleteSecret` and dynamic secret DELETE operations send request body (previously broken by `{ data }` mapping gap)
- [x] Retry behavior on 429 responses works as expected
- [x] Error messages from `newInfisicalError` contain status code, URL, and method
- [x] CJS and ESM support

```
npx attw -P .                                                       

@infisical/sdk v0.0.0

Build tools:
- typescript@^5.5.4
- tsup@^8.5.1

 No problems found 🌟


┌───────────────────┬──────────────────┐
│                   │ "@infisical/sdk" │
├───────────────────┼──────────────────┤
│ node10            │ 🟢               │
├───────────────────┼──────────────────┤
│ node16 (from CJS) │ 🟢 (CJS)         │
├───────────────────┼──────────────────┤
│ node16 (from ESM) │ 🟢 (ESM)         │
├───────────────────┼──────────────────┤
│ bundler           │ 🟢               │
└───────────────────┴──────────────────┘
```